### PR TITLE
fix explosive bullets working randomly

### DIFF
--- a/scripts/vscripts/popextensions/customattributes.nut
+++ b/scripts/vscripts/popextensions/customattributes.nut
@@ -1009,7 +1009,7 @@
 
 			scope.ItemThinkTable[format("ExplosiveBullets_%d_%d", player.GetScriptScope().userid,  wep.entindex())] <- function() {
 
-				if (!("explosive bullets" in player.GetScriptScope().attribinfo) || player.GetActiveWeapon() != wep || scope.explosivebulletsnextattack == GetPropFloat(wep, "m_flLastFireTime") || ("curclip" in scope && scope.curclip != wep.Clip1())) return
+				if (!("explosive bullets" in player.GetScriptScope().attribinfo) || player.GetActiveWeapon() != wep || scope.explosivebulletsnextattack == GetPropFloat(wep, "m_flLastFireTime")) return
 
 				local grenade = CreateByClassname("tf_projectile_pipe")
 				SetPropEntity(grenade, "m_hOwnerEntity", launcher)


### PR DESCRIPTION
Removed "("curclip" in scope && scope.curclip != wep.Clip1()" from the explosivebullets return check, so a gun with explosive bullets now properly makes explosions happen per shot.

I know this is going to change later but for now, let the thing work as it's written.